### PR TITLE
feat: add API gateway domain and certificate

### DIFF
--- a/terragrunt/aws/domain/api_gateway.tf
+++ b/terragrunt/aws/domain/api_gateway.tf
@@ -1,0 +1,19 @@
+resource "aws_api_gateway_domain_name" "docs_platform_mvp" {
+  regional_certificate_arn = aws_acm_certificate.docs_platform_mvp.arn
+  domain_name              = var.domain_name
+  security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_api_gateway_base_path_mapping" "docs_platform_mvp" {
+  domain_name = aws_api_gateway_domain_name.docs_platform_mvp.domain_name
+  api_id      = data.aws_api_gateway_rest_api.docs_platform_mvp.id
+  stage_name  = var.api_stage_name
+}

--- a/terragrunt/aws/domain/certificate.tf
+++ b/terragrunt/aws/domain/certificate.tf
@@ -1,0 +1,18 @@
+resource "aws_acm_certificate" "docs_platform_mvp" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "docs_platform_mvp" {
+  certificate_arn         = aws_acm_certificate.docs_platform_mvp.arn
+  validation_record_fqdns = [for record in aws_route53_record.docs_platform_mvp_validation : record.fqdn]
+}

--- a/terragrunt/aws/domain/data.tf
+++ b/terragrunt/aws/domain/data.tf
@@ -1,0 +1,3 @@
+data "aws_api_gateway_rest_api" "docs_platform_mvp" {
+  name = var.api_name
+}

--- a/terragrunt/aws/domain/inputs.tf
+++ b/terragrunt/aws/domain/inputs.tf
@@ -1,5 +1,15 @@
+variable "api_name" {
+  description = "(Required) name of the Platform MVP REST API"
+  type        = string
+}
+
+variable "api_stage_name" {
+  description = "(Required) name of the Platform MVP REST API stage for the base path mapping"
+  type        = string
+}
+
 variable "domain_name" {
-  description = "(required) domain name to use for for the Platform MVP CMS project"
+  description = "(Required) domain name to use for for the Platform MVP CMS project"
   type        = string
   sensitive   = true
 }

--- a/terragrunt/aws/domain/route53.tf
+++ b/terragrunt/aws/domain/route53.tf
@@ -5,3 +5,34 @@ resource "aws_route53_zone" "docs_platform_mvp" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
+
+resource "aws_route53_record" "docs_platform_mvp_A" {
+  zone_id = aws_route53_zone.docs_platform_mvp.zone_id
+  name    = aws_route53_zone.docs_platform_mvp.name
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.docs_platform_mvp.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.docs_platform_mvp.regional_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "docs_platform_mvp_validation" {
+  zone_id = aws_route53_zone.docs_platform_mvp.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.docs_platform_mvp.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+
+  ttl = 60
+}

--- a/terragrunt/env/dev/domain/terragrunt.hcl
+++ b/terragrunt/env/dev/domain/terragrunt.hcl
@@ -1,6 +1,10 @@
-
 include {
   path = find_in_parent_folders()
+}
+
+inputs = {
+  api_name       = "dev-aws-node-express-api"
+  api_stage_name = "dev"
 }
 
 terraform {


### PR DESCRIPTION
# Summary
This creates an "A" record for the domain that references the
API gateway's custom domain.  It also adds creates a certificate
and validation records for the new domain.

# Expected changes
* DNS records for the domain and certificate validation
* API gateway domain
* API gateway certificate
* API gateway base path mapping