### PR TITLE
feat: switch to platform.cdssandbox.xyz domain

### DIFF
--- a/.github/workflows/terragrunt-apply-dev.yml
+++ b/.github/workflows/terragrunt-apply-dev.yml
@@ -15,7 +15,6 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.2
   TERRAGRUNT_VERSION: 0.31.0
-  TF_VAR_domain_name: ${{ secrets.DEV_DOMAIN_NAME }}
 
 jobs:
   terragrunt-apply-dev:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -11,7 +11,6 @@ env:
   TERRAFORM_VERSION: 1.0.2
   TERRAGRUNT_VERSION: 0.31.0
   TF_INPUT: false
-  TF_VAR_domain_name: ${{ secrets.DEV_DOMAIN_NAME }}
 
 jobs:
 

--- a/terragrunt/aws/domain/api_gateway.tf
+++ b/terragrunt/aws/domain/api_gateway.tf
@@ -1,5 +1,5 @@
-resource "aws_api_gateway_domain_name" "docs_platform_mvp" {
-  regional_certificate_arn = aws_acm_certificate.docs_platform_mvp.arn
+resource "aws_api_gateway_domain_name" "platform_mvp" {
+  regional_certificate_arn = aws_acm_certificate.platform_mvp.arn
   domain_name              = var.domain_name
   security_policy          = "TLS_1_2"
 
@@ -10,10 +10,14 @@ resource "aws_api_gateway_domain_name" "docs_platform_mvp" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
+
+  depends_on = [
+    aws_acm_certificate_validation.platform_mvp
+  ]
 }
 
-resource "aws_api_gateway_base_path_mapping" "docs_platform_mvp" {
-  domain_name = aws_api_gateway_domain_name.docs_platform_mvp.domain_name
-  api_id      = data.aws_api_gateway_rest_api.docs_platform_mvp.id
+resource "aws_api_gateway_base_path_mapping" "platform_mvp" {
+  domain_name = aws_api_gateway_domain_name.platform_mvp.domain_name
+  api_id      = data.aws_api_gateway_rest_api.platform_mvp.id
   stage_name  = var.api_stage_name
 }

--- a/terragrunt/aws/domain/certificate.tf
+++ b/terragrunt/aws/domain/certificate.tf
@@ -6,6 +6,10 @@ resource "aws_acm_certificate" "platform_mvp" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "platform_mvp_validation" {

--- a/terragrunt/aws/domain/certificate.tf
+++ b/terragrunt/aws/domain/certificate.tf
@@ -1,4 +1,4 @@
-resource "aws_acm_certificate" "docs_platform_mvp" {
+resource "aws_acm_certificate" "platform_mvp" {
   domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]
   validation_method         = "DNS"
@@ -6,13 +6,27 @@ resource "aws_acm_certificate" "docs_platform_mvp" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
-resource "aws_acm_certificate_validation" "docs_platform_mvp" {
-  certificate_arn         = aws_acm_certificate.docs_platform_mvp.arn
-  validation_record_fqdns = [for record in aws_route53_record.docs_platform_mvp_validation : record.fqdn]
+resource "aws_route53_record" "platform_mvp_validation" {
+  zone_id = aws_route53_zone.platform_mvp.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.platform_mvp.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "platform_mvp" {
+  certificate_arn         = aws_acm_certificate.platform_mvp.arn
+  validation_record_fqdns = [for record in aws_route53_record.platform_mvp_validation : record.fqdn]
 }

--- a/terragrunt/aws/domain/data.tf
+++ b/terragrunt/aws/domain/data.tf
@@ -1,3 +1,3 @@
-data "aws_api_gateway_rest_api" "docs_platform_mvp" {
+data "aws_api_gateway_rest_api" "platform_mvp" {
   name = var.api_name
 }

--- a/terragrunt/aws/domain/inputs.tf
+++ b/terragrunt/aws/domain/inputs.tf
@@ -11,5 +11,4 @@ variable "api_stage_name" {
 variable "domain_name" {
   description = "(Required) domain name to use for for the Platform MVP CMS project"
   type        = string
-  sensitive   = true
 }

--- a/terragrunt/aws/domain/route53.tf
+++ b/terragrunt/aws/domain/route53.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "docs_platform_mvp" {
+resource "aws_route53_zone" "platform_mvp" {
   name = var.domain_name
 
   tags = {
@@ -6,33 +6,14 @@ resource "aws_route53_zone" "docs_platform_mvp" {
   }
 }
 
-resource "aws_route53_record" "docs_platform_mvp_A" {
-  zone_id = aws_route53_zone.docs_platform_mvp.zone_id
-  name    = aws_route53_zone.docs_platform_mvp.name
+resource "aws_route53_record" "platform_mvp_A" {
+  zone_id = aws_route53_zone.platform_mvp.zone_id
+  name    = aws_route53_zone.platform_mvp.name
   type    = "A"
 
   alias {
-    name                   = aws_api_gateway_domain_name.docs_platform_mvp.regional_domain_name
-    zone_id                = aws_api_gateway_domain_name.docs_platform_mvp.regional_zone_id
+    name                   = aws_api_gateway_domain_name.platform_mvp.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.platform_mvp.regional_zone_id
     evaluate_target_health = false
   }
-}
-
-resource "aws_route53_record" "docs_platform_mvp_validation" {
-  zone_id = aws_route53_zone.docs_platform_mvp.zone_id
-
-  for_each = {
-    for dvo in aws_acm_certificate.docs_platform_mvp.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
-
-    }
-  }
-
-  name    = each.value.name
-  records = [each.value.record]
-  type    = each.value.type
-
-  ttl = 60
 }

--- a/terragrunt/env/dev/domain/terragrunt.hcl
+++ b/terragrunt/env/dev/domain/terragrunt.hcl
@@ -5,6 +5,7 @@ include {
 inputs = {
   api_name       = "dev-aws-node-express-api"
   api_stage_name = "dev"
+  domain_name    = "platform.cdssandbox.xyz"
 }
 
 terraform {


### PR DESCRIPTION
# Summary 
There are additional AWS validation steps we need for the `*.digital.canada.ca` cert because it's getting caught up in "Alexa 1,000 most popular sites" fraud detection logic.

In the interest of speed, we're switching to a `cdssandbox.xyz` subdomain to test.

# Expected changes
None, this was applied locally to test.