### PR TITLE
Theme fixes

### DIFF
--- a/cds-snc-docs/packages/cds-docs-theme/src/components/Header.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/Header.js
@@ -18,9 +18,9 @@ export const Header = ({ state }) => {
     <header>
       <div className="wrap">
         <div className="site-title">
-          <a className="title-link" href="#">
+          <Link className="title-link" link="/">
             {name}
-          </a>
+          </Link>
         </div>
         <h2 className="float-right">{languageToggle(state)}</h2>
       </div>

--- a/cds-snc-docs/packages/cds-docs-theme/src/components/SideNav.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/SideNav.js
@@ -10,16 +10,19 @@ const isActive = (state, link) => {
   return null;
 };
 
-const SideNav = ({ state }) => {
+const SideNav = ({ state, libraries }) => {
   const items = state.source.get(`/menu/${state.theme.menuUrl}/`).items;
   const { description } = state.source.get("nameAndDescription");
+  const Html2React = libraries.html2react.Component;
 
   if (!items) {
     return null;
   }
   return (
     <aside>
-      <p className="intro">{description}</p>
+      <p className="intro">
+        <Html2React html={description} />
+      </p>
       <nav className="sidebar-nav">
         <ul>
           {items.map((item) => {


### PR DESCRIPTION
Fixes SideBar nav - now decodes HTML chars 

<img width="430" alt="Screen Shot 2021-07-15 at 5 37 54 AM" src="https://user-images.githubusercontent.com/62242/125787595-a7e377c7-33ed-426f-ad2c-8fea63239871.png">

Update Header to use <Link> component vs <a> --- this makes for better package naviagtion
<img width="342" alt="Screen Shot 2021-07-15 at 5 38 25 AM" src="https://user-images.githubusercontent.com/62242/125787701-04bb5207-2a45-49b2-82ad-07ce88c03343.png">
