### PR TITLE
Update deploy to use default profile vs custom

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,6 @@ jobs:
       run: |
         cd server
         npm ci
-        node ./node_modules/serverless/bin/serverless.js config credentials --provider aws --key ${{ secrets.DEV_AWS_ACCESS_KEY_ID }} --secret ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }} --profile papaya --overwrite
+        node ./node_modules/serverless/bin/serverless.js config credentials --provider aws --key ${{ secrets.DEV_AWS_ACCESS_KEY_ID }} --secret ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
         node ./node_modules/serverless/bin/serverless.js deploy --aws-s3-accelerate --stage dev --verbose
       


### PR DESCRIPTION
The deploy script is currently failing 

```
Serverless Error ----------------------------------------
 
AWS provider credentials not found. Learn how to set up AWS provider credentials in our docs here: 
```

Try using the default profile

