### PR TITLE
fix: WAF association with API and CloudFront

### DIFF
--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -24,7 +24,7 @@ resource "aws_cloudfront_distribution" "platform_mvp" {
 
   enabled         = true
   is_ipv6_enabled = true
-  web_acl_id      = var.cloudfront_waf_acl_id
+  web_acl_id      = var.cloudfront_waf_acl_arn
 
   aliases = [var.domain_name]
 
@@ -43,8 +43,8 @@ resource "aws_cloudfront_distribution" "platform_mvp" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 7200
+    default_ttl            = 0
+    max_ttl                = 0
     compress               = true
   }
 

--- a/terragrunt/aws/cloudfront/inputs.tf
+++ b/terragrunt/aws/cloudfront/inputs.tf
@@ -1,15 +1,5 @@
-variable "api_name" {
-  description = "(Required) name of the Platform MVP REST API"
-  type        = string
-}
-
-variable "api_stage_name" {
-  description = "(Required) name of the Platform MVP REST API stage for the base path mapping"
-  type        = string
-}
-
-variable "cloudfront_waf_acl_id" {
-  description = "(Required) ID of the WAF ACL for the CloudFront distribution"
+variable "cloudfront_waf_acl_arn" {
+  description = "(Required) ARN of the WAF ACL for the CloudFront distribution"
   type        = string
 }
 

--- a/terragrunt/aws/waf/inputs.tf
+++ b/terragrunt/aws/waf/inputs.tf
@@ -1,4 +1,0 @@
-variable "api_name" {
-  description = "(Required) name of the Platform MVP REST API"
-  type        = string
-}

--- a/terragrunt/aws/waf/outputs.tf
+++ b/terragrunt/aws/waf/outputs.tf
@@ -1,9 +1,9 @@
-output "api_waf_acl_id" {
-  value       = aws_wafv2_web_acl.platform_mvp_api.id
-  description = "ID of the WAF ACL for the API"
+output "api_waf_acl_arn" {
+  value       = aws_wafv2_web_acl.platform_mvp_api.arn
+  description = "ARN of the WAF ACL for the API"
 }
 
-output "cloudfront_waf_acl_id" {
-  value       = aws_wafv2_web_acl.platform_mvp_cloudfront.id
-  description = "ID of the WAF ACL for the CloudFront distribution"
+output "cloudfront_waf_acl_arn" {
+  value       = aws_wafv2_web_acl.platform_mvp_cloudfront.arn
+  description = "ARN of the WAF ACL for the CloudFront distribution"
 }

--- a/terragrunt/aws/waf/waf.tf
+++ b/terragrunt/aws/waf/waf.tf
@@ -189,6 +189,6 @@ resource "aws_wafv2_web_acl" "platform_mvp_cloudfront" {
 # AWS WAF - Resource Assocation
 ###
 resource "aws_wafv2_web_acl_association" "platform_mvp_api" {
-  resource_arn = data.aws_api_gateway_rest_api.platform_mvp.arn
+  resource_arn = "${data.aws_api_gateway_rest_api.platform_mvp.arn}/stages/${var.api_stage_name}"
   web_acl_arn  = aws_wafv2_web_acl.platform_mvp_api.arn
 }

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -3,6 +3,16 @@ variable "account_id" {
   type        = string
 }
 
+variable "api_name" {
+  description = "(Required) name of the Platform MVP REST API"
+  type        = string
+}
+
+variable "api_stage_name" {
+  description = "(Required) name of the Platform MVP REST API stage for the base path mapping"
+  type        = string
+}
+
 variable "billing_tag_key" {
   description = "(Required) the key we use to track billing"
   type        = string

--- a/terragrunt/env/dev/cloudfront/terragrunt.hcl
+++ b/terragrunt/env/dev/cloudfront/terragrunt.hcl
@@ -11,15 +11,13 @@ dependency "waf" {
 
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs = {
-    cloudfront_waf_acl_id = ""
+    cloudfront_waf_acl_arn = ""
   }
 }
 
 inputs = {
-  api_name              = "dev-aws-node-express-api"
-  api_stage_name        = "dev"
-  cloudfront_waf_acl_id = dependency.waf.outputs.cloudfront_waf_acl_id
-  domain_name           = "platform.cdssandbox.xyz"
+  cloudfront_waf_acl_arn  = dependency.waf.outputs.cloudfront_waf_acl_arn
+  domain_name             = "platform.cdssandbox.xyz"
 }
 
 terraform {

--- a/terragrunt/env/dev/env_vars.hcl
+++ b/terragrunt/env/dev/env_vars.hcl
@@ -1,5 +1,7 @@
 inputs = {
   account_id                      = "527289287223"
+  api_name                        = "dev-aws-node-express-api"
+  api_stage_name                  = "dev"
   env                             = "dev"
   billing_tag_key                 = "CostCentre"
   billing_tag_value               = "PlatformMVP"

--- a/terragrunt/env/dev/waf/terragrunt.hcl
+++ b/terragrunt/env/dev/waf/terragrunt.hcl
@@ -2,10 +2,6 @@ include {
   path = find_in_parent_folders()
 }
 
-inputs = {
-  api_name = "dev-aws-node-express-api"
-}
-
 terraform {
   source = "../../../aws//waf"
 }

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -4,6 +4,8 @@ locals {
 
 inputs = {
   account_id                      = "${local.vars.inputs.account_id}"
+  api_name                        = "${local.vars.inputs.api_name}"
+  api_stage_name                  = "${local.vars.inputs.api_stage_name}"
   billing_tag_key                 = "${local.vars.inputs.billing_tag_key}"
   billing_tag_value               = "${local.vars.inputs.billing_tag_value}"
   cloudfront_custom_header_name   = "${local.vars.inputs.cloudfront_custom_header_name}"


### PR DESCRIPTION
# Summary
* Fixes the association of the WAF ACLs with the API and CloudFront.
* Sets the CloudFront cache TTLs back to 0 to help with testing.
* Moves the `api_name` and `api_stage_name` variables into `common_variables.tf` to remove duplication.

# Expected changes
None, this was applied locally to test the fix.

Related #10