### PR TITLE
fix: use secret for CloudFront custom header

### DIFF
--- a/.github/workflows/terragrunt-apply-dev.yml
+++ b/.github/workflows/terragrunt-apply-dev.yml
@@ -15,6 +15,8 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.2
   TERRAGRUNT_VERSION: 0.31.0
+  TF_VAR_cloudfront_custom_header_name: ${{ secrets.DEV_CLOUDFRONT_CUSTOM_HEADER_NAME }}
+  TF_VAR_cloudfront_custom_header_value: ${{ secrets.DEV_CLOUDFRONT_CUSTOM_HEADER_VALUE }}
 
 jobs:
   terragrunt-apply-dev:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -45,6 +45,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}
+          TF_VAR_cloudfront_custom_header_name: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_NAME',matrix.environment)] }}
+          TF_VAR_cloudfront_custom_header_value: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_VALUE',matrix.environment)] }}
         uses: cds-snc/terraform-plan@v1
         with:
           directory: "terragrunt/env/${{ matrix.environment }}/${{ matrix.module_name }}"
@@ -85,6 +87,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}
+          TF_VAR_cloudfront_custom_header_name: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_NAME',matrix.environment)] }}
+          TF_VAR_cloudfront_custom_header_value: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_VALUE',matrix.environment)] }}
         uses: cds-snc/terraform-plan@v1
         with:
           directory: "terragrunt/env/${{ matrix.environment }}/${{ matrix.module_name }}"

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -26,11 +26,13 @@ variable "billing_tag_value" {
 variable "cloudfront_custom_header_name" {
   description = "(Required) custom header added to CloudFront requests to the origin"
   type        = string
+  sensitive   = true
 }
 
 variable "cloudfront_custom_header_value" {
   description = "(Required) custer header value added to CloudFront requests to the origin"
   type        = string
+  sensitive   = true
 }
 
 variable "env" {

--- a/terragrunt/env/dev/env_vars.hcl
+++ b/terragrunt/env/dev/env_vars.hcl
@@ -5,6 +5,4 @@ inputs = {
   env                             = "dev"
   billing_tag_key                 = "CostCentre"
   billing_tag_value               = "PlatformMVP"
-  cloudfront_custom_header_name   = "platform_mvp"
-  cloudfront_custom_header_value  = "5ViyiIB5meNTQDVvxBoz9XLT"  
 }

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -8,8 +8,6 @@ inputs = {
   api_stage_name                  = "${local.vars.inputs.api_stage_name}"
   billing_tag_key                 = "${local.vars.inputs.billing_tag_key}"
   billing_tag_value               = "${local.vars.inputs.billing_tag_value}"
-  cloudfront_custom_header_name   = "${local.vars.inputs.cloudfront_custom_header_name}"
-  cloudfront_custom_header_value  = "${local.vars.inputs.cloudfront_custom_header_value}"
   env                             = "${local.vars.inputs.env}"
   region                          = "ca-central-1"
 }


### PR DESCRIPTION
# Summary
The custom header  is used to prevent direct access to the API stage without going through CloudFront.  This change removes the custom header name and value from the repo and injects them into the workflow using secrets.

# Expected changes
* Update the API's WAF ACL with new header name/value
* Update CloudFront distribution with new header name/value

Related #10 