### PR TITLE
Fix source for menus

### DIFF
--- a/cds-snc-docs/config/alerte-covid.js
+++ b/cds-snc-docs/config/alerte-covid.js
@@ -1,12 +1,15 @@
 export const alerteCovid = {
   name: "alerte-covid",
-  match: [".*https?://localhost:4000", "\/alerte-covid"],
+  match: [".*https?://localhost:4000", "/alerte-covid"],
   state: {
     frontity: {
       title: "Alerte COVID",
       description:
         "Alerte COVID est l'application gratuite de notification d'exposition du Canada.",
       url: "https://platform.cdssandbox.xyz/alerte-covid",
+      menuUrl: "main-fr",
+      footerUrl: "footer-fr",
+      languageUrl: "language-fr",
     },
   },
   packages: [

--- a/cds-snc-docs/config/covid-alert.js
+++ b/cds-snc-docs/config/covid-alert.js
@@ -10,6 +10,9 @@ export const covidAlert = {
       description:
         "COVID Alert is Canada's free COVID-19 exposure notification app.",
       url: "https://platform.cdssandbox.xyz/covid-alert",
+      menuUrl: "main",
+      footerUrl: "footer",
+      languageUrl: "language",
     },
   },
   packages: [

--- a/cds-snc-docs/packages/cds-docs-theme/src/components/Footer.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/Footer.js
@@ -1,20 +1,19 @@
 import React from "react";
 import { connect } from "frontity";
+import Link from "@frontity/components/link";
 
-const getLink = (item) => {
-  if(!item) return null
-  return <a href={item.url}>{item.title}</a>;
-};
 
 const Footer = ({ state }) => {
-  const items = state.source.get(`/menu/${state.theme.footerUrl}/`).items;
-  if(!items) return null
+  const items = state.source.get(`/menu/${state.frontity.footerUrl}/`).items;
+  
+  if (!items) return null;
+
   return (
     <footer>
       <div className="wrap">
-        <p>
-          This project was built by the {getLink(items[0])}.
-        </p>
+        {items.map((item) => {
+          return <Link key={item.ID} link={item.url}>{item.title}</Link>;
+        })}
       </div>
     </footer>
   );

--- a/cds-snc-docs/packages/cds-docs-theme/src/components/Header.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/Header.js
@@ -3,13 +3,15 @@ import { connect } from "frontity";
 import Link from "@frontity/components/link";
 
 const languageToggle = (state) => {
-  const items = state.source.get(`/menu/${state.theme.languageUrl}/`).items;
+  const items = state.source.get(`/menu/${state.frontity.languageUrl}/`).items;
 
-  if (items && items[0]) {
-    return <Link link={items[0].url}>{items[0].title}</Link>;
+  if (!items) {
+    return null;
   }
 
-  return null;
+  return items.map((item) => {
+    return <Link key={item.ID} link={item.url}>{item.title}</Link>;
+  });
 };
 
 export const Header = ({ state }) => {

--- a/cds-snc-docs/packages/cds-docs-theme/src/components/SideNav.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/SideNav.js
@@ -11,13 +11,14 @@ const isActive = (state, link) => {
 };
 
 const SideNav = ({ state, libraries }) => {
-  const items = state.source.get(`/menu/${state.theme.menuUrl}/`).items;
+  const items = state.source.get(`/menu/${state.frontity.menuUrl}/`).items;
   const description = state.frontity.description;
   const Html2React = libraries.html2react.Component;
 
   if (!items) {
     return null;
   }
+  
   return (
     <aside>
       <p className="intro">

--- a/cds-snc-docs/packages/cds-docs-theme/src/components/handlers/menu-handler.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/components/handlers/menu-handler.js
@@ -4,6 +4,8 @@ const menuHandler = {
     pattern: "/menu/:slug",
     func: async ({ link, params, state, libraries }) => {
       const { slug } = params;
+
+      // https://platform.digital.canada.ca/covid-alert/fr/wp-json/menus/v1/menus/
   
       // Fetch the menu data from the endpoint
       const response = await libraries.source.api.get({

--- a/cds-snc-docs/packages/cds-docs-theme/src/index.js
+++ b/cds-snc-docs/packages/cds-docs-theme/src/index.js
@@ -5,9 +5,9 @@ import link from "@frontity/html2react/processors/link";
 import menuHandler from "./components/handlers/menu-handler";
 
 const beforeSSR = async ({ state, libraries, actions }) => {
-  await actions.source.fetch(`/menu/${state.theme.menuUrl}/`);
-  await actions.source.fetch(`/menu/${state.theme.footerUrl}/`);
-  await actions.source.fetch(`/menu/${state.theme.languageUrl}/`);
+  await actions.source.fetch(`/menu/${state.frontity.menuUrl}/`);
+  await actions.source.fetch(`/menu/${state.frontity.footerUrl}/`);
+  await actions.source.fetch(`/menu/${state.frontity.languageUrl}/`);
   // Add image processor.
   libraries.html2react.processors.push(image);
 };
@@ -34,9 +34,6 @@ const cdsDocsTheme = {
     theme: {
       autoPrefetch: "in-view",
       menu: [],
-      menuUrl: "main",
-      footerUrl: "footer",
-      languageUrl :"language",
       featured: {
         showOnList: false,
         showOnPost: false,


### PR DESCRIPTION
Moves the api source for menus to use Frontity state vs Theme state.

This PR also update the way items are mapped over.  The code will now map over all items pulled from the API.