### PR TITLE
feat: use Simple Email Service to send email

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -20,49 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - module_name: waf
-            environment: dev
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: Terragrunt plan
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}
-          TF_VAR_cloudfront_custom_header_name: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_NAME',matrix.environment)] }}
-          TF_VAR_cloudfront_custom_header_value: ${{ secrets[format('{0}_CLOUDFRONT_CUSTOM_HEADER_VALUE',matrix.environment)] }}
-        uses: cds-snc/terraform-plan@v1
-        with:
-          directory: "infrastructure/terragrunt/env/${{ matrix.environment }}/${{ matrix.module_name }}"
-          comment-delete: "true"
-          comment-title: "${{ matrix.environment }}: ${{ matrix.module_name }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          terragrunt: "true"
-
-  terragrunt-plan-deps:
-    needs: [terragrunt-plan]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
           - module_name: cloudfront
+            environment: dev
+          - module_name: ses
+            environment: dev
+          - module_name: waf
             environment: dev
 
     steps:
@@ -99,7 +61,7 @@ jobs:
 
   comment-end:
     if: always()
-    needs: [terragrunt-plan-deps]
+    needs: [terragrunt-plan]
     runs-on: ubuntu-latest
     steps:
 

--- a/infrastructure/terragrunt/aws/cloudfront/outputs.tf
+++ b/infrastructure/terragrunt/aws/cloudfront/outputs.tf
@@ -1,0 +1,9 @@
+output "domain_name" {
+  description = "Domain name 'A' record of the Platform MVP site"
+  value       = aws_route53_record.platform_mvp_A.name
+}
+
+output "route53_zone_id" {
+  description = "Route53 zone ID used to manage the Platform MVP records"
+  value       = aws_route53_zone.platform_mvp.zone_id
+}

--- a/infrastructure/terragrunt/aws/ses/inputs.tf
+++ b/infrastructure/terragrunt/aws/ses/inputs.tf
@@ -1,0 +1,9 @@
+variable "route53_zone_id" {
+  description = "Route53 zone to create the SES verification and DKIM records in"
+  type        = string
+}
+
+variable "ses_sending_domain" {
+  description = "Domain that will be used by SES to send emails from."
+  type        = string
+}

--- a/infrastructure/terragrunt/aws/ses/outputs.tf
+++ b/infrastructure/terragrunt/aws/ses/outputs.tf
@@ -1,0 +1,11 @@
+output "ses_smtp_username" {
+  description = "Username for the SMTP IAM user"
+  value       = aws_iam_access_key.ses_smtp_user.id
+  sensitive   = true
+}
+
+output "ses_smtp_password" {
+  description = "Password for the SMTP IAM user"
+  value       = aws_iam_access_key.ses_smtp_user.ses_smtp_password_v4
+  sensitive   = true
+}

--- a/infrastructure/terragrunt/aws/ses/route53.tf
+++ b/infrastructure/terragrunt/aws/ses/route53.tf
@@ -1,0 +1,23 @@
+# DNS SES verification and DomainKeys Identified Mail (DKIM) records
+# https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim.html
+resource "aws_route53_record" "platform_mvp_dkim" {
+  count = 3
+
+  zone_id = var.route53_zone_id
+  name = format(
+    "%s._domainkey.%s",
+    element(aws_ses_domain_dkim.platform_mvp_domain_dkim.dkim_tokens, count.index),
+    var.ses_sending_domain,
+  )
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.platform_mvp_domain_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "platform_mvp_ses_verification" {
+  zone_id = var.route53_zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.platform_mvp_sending_domain.id}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [aws_ses_domain_identity.platform_mvp_sending_domain.verification_token]
+}

--- a/infrastructure/terragrunt/aws/ses/ses.tf
+++ b/infrastructure/terragrunt/aws/ses/ses.tf
@@ -1,0 +1,48 @@
+# SES domain identity, verification and custom MAIL FROM domain
+resource "aws_ses_domain_identity" "platform_mvp_sending_domain" {
+  domain = var.ses_sending_domain
+}
+
+resource "aws_ses_domain_dkim" "platform_mvp_domain_dkim" {
+  domain = var.ses_sending_domain
+}
+
+resource "aws_ses_domain_identity_verification" "platform_mvp_domain_verification" {
+  domain     = aws_ses_domain_identity.platform_mvp_sending_domain.id
+  depends_on = [aws_route53_record.platform_mvp_ses_verification]
+}
+
+resource "aws_ses_domain_mail_from" "platform_mvp_domain_mail_from" {
+  domain           = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  mail_from_domain = "mail.${aws_ses_domain_identity.platform_mvp_sending_domain.domain}"
+}
+
+# SNS topic that receives bounce, delivery and complaint notifications 
+# from to SES email sending
+resource "aws_sns_topic" "platform_mvp_ses" {
+  name              = "ses-notifications"
+  kms_master_key_id = "alias/aws/sns"
+}
+
+resource "aws_ses_identity_notification_topic" "platform_mvp_ses_bounce_topic" {
+  topic_arn                = aws_sns_topic.platform_mvp_ses.arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "cplatform_mvp_ses_delivery_topic" {
+  topic_arn                = aws_sns_topic.platform_mvp_ses.arn
+  notification_type        = "Delivery"
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "platform_mvp_ses_complaint_topic" {
+  topic_arn                = aws_sns_topic.platform_mvp_ses.arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  include_original_headers = false
+}
+
+

--- a/infrastructure/terragrunt/aws/ses/smtp-user.tf
+++ b/infrastructure/terragrunt/aws/ses/smtp-user.tf
@@ -1,0 +1,27 @@
+# IAM user whose credentials will be used to send email through SES
+resource "aws_iam_user" "ses_smtp_user" {
+  name = "ses_smtp_user"
+}
+
+resource "aws_iam_access_key" "ses_smtp_user" {
+  user = aws_iam_user.ses_smtp_user.name
+}
+
+data "aws_iam_policy_document" "ses_sender" {
+  statement {
+    actions   = ["ses:SendRawEmail"]
+    resources = ["${aws_ses_domain_identity.platform_mvp_sending_domain.arn}*"]
+  }
+}
+
+resource "aws_iam_policy" "ses_sender" {
+  name        = "ses_sender"
+  description = "Allows sending email via SES"
+  policy      = data.aws_iam_policy_document.ses_sender.json
+}
+
+resource "aws_iam_user_policy_attachment" "ses_sender_policy_attach" {
+  # checkov:skip=CKV_AWS_40:acceptable to attach policy directly to the user
+  user       = aws_iam_user.ses_smtp_user.name
+  policy_arn = aws_iam_policy.ses_sender.arn
+}

--- a/infrastructure/terragrunt/env/dev/cloudfront/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/dev/cloudfront/terragrunt.hcl
@@ -16,8 +16,8 @@ dependency "waf" {
 }
 
 inputs = {
-  cloudfront_waf_acl_arn  = dependency.waf.outputs.cloudfront_waf_acl_arn
-  domain_name             = "platform.cdssandbox.xyz"
+  cloudfront_waf_acl_arn = dependency.waf.outputs.cloudfront_waf_acl_arn
+  domain_name            = "platform.cdssandbox.xyz"
 }
 
 terraform {

--- a/infrastructure/terragrunt/env/dev/ses/.terraform.lock.hcl
+++ b/infrastructure/terragrunt/env/dev/ses/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.53.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:oRCCzfwGCDNyuhIJ8kCg0N7h4W2WESm37o2GIt0ETpQ=",
+    "zh:35a77c79170b0cf3fb7eb835f3ce0b715aeeceda0a259e96e49fed5a30cf6646",
+    "zh:519d5470a932b1ec9a0fe08876c5e0f0f84f8e506b652c051e4ab708be081e89",
+    "zh:58cfa5b454602d57c47acd15c2ad166a012574742cdbcf950787ce79b6510218",
+    "zh:5fc3c0162335a730701c0175809250233f45f1021da8fa52c73635e4c08372d8",
+    "zh:6790f9d6261eb4bd5cdd7cd9125f103befce2ba127f9ba46eef83585b86e1d11",
+    "zh:76e1776c3bf9568d520f78419ec143c081f653b8df4fb22577a8c4a35d3315f9",
+    "zh:ca8ed88d0385e45c35223ace59b1bf77d81cd2154d5416e63a3dddaf0def30e6",
+    "zh:d002562c4a89a9f1f6cd8d854fad3c66839626fc260e5dde5267f6d34dbd97a4",
+    "zh:da5e47fb769e90a2f16c90fd0ba95d62da3d76eb006823664a5c6e96188731b0",
+    "zh:dfe7f33ec252ea550e090975a5f10940c27302bebb5559957957937b069646ea",
+    "zh:fa91574605ddce726e8a4e421297009a9dabe023106e139ac46da49c8285f2fe",
+  ]
+}

--- a/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
@@ -1,0 +1,26 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependencies {
+  paths = ["../cloudfront"]
+}
+
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    route53_zone_id = ""
+    domain_name     = ""
+  }
+}
+
+inputs = {
+  route53_zone_id    = dependency.cloudfront.outputs.route53_zone_id
+  ses_sending_domain = dependency.cloudfront.outputs.domain_name
+}
+
+terraform {
+  source = "../../../aws//ses"
+}


### PR DESCRIPTION
# Summary
1. Creates a SES domain identity for `platform.cdssandbox.xyz` along with the Route53 validation records.
1. Creates an IAM user that will be used by the app to send email.
1. Removes the `terragrunt-plan-deps` job from the Terraform plan workflow so that all modules are planned in a single job.