### PR TITLE
fix: add CMK to encrypt SNS topic

### DIFF
--- a/infrastructure/terragrunt/aws/ses/kms.tf
+++ b/infrastructure/terragrunt/aws/ses/kms.tf
@@ -1,0 +1,65 @@
+resource "aws_kms_key" "sns" {
+  description         = "SNS topic encryption key"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.sns_kms_policy.json
+}
+
+data "aws_iam_policy_document" "sns_kms_policy" {
+  policy_id = "key-policy-sns"
+  statement {
+    sid = "Enable IAM User Permissions"
+    actions = [
+      "kms:*",
+    ]
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+    resources = ["arn:aws:kms:${var.region}:${var.account_id}:key/*"]
+  }
+  statement {
+    sid    = "Allow CloudWatch"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    resources = ["arn:aws:kms:${var.region}:${var.account_id}:key/*"]
+  }
+  statement {
+    sid    = "Allow CloudWatch Events"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    resources = ["arn:aws:kms:${var.region}:${var.account_id}:key/*"]
+  }
+  statement {
+    sid    = "Allow SNS"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+    resources = ["arn:aws:kms:${var.region}:${var.account_id}:key/*"]
+  }
+}
+
+resource "aws_kms_alias" "sns" {
+  name          = "alias/sns"
+  target_key_id = aws_kms_key.sns.key_id
+}

--- a/infrastructure/terragrunt/aws/ses/ses.tf
+++ b/infrastructure/terragrunt/aws/ses/ses.tf
@@ -20,28 +20,28 @@ resource "aws_ses_domain_mail_from" "platform_mvp_domain_mail_from" {
 # SNS topic that receives bounce, delivery and complaint notifications 
 # from to SES email sending
 resource "aws_sns_topic" "platform_mvp_ses" {
-  name              = "ses-notifications"
-  kms_master_key_id = "alias/aws/sns"
+  name              = "ses-notify"
+  kms_master_key_id = aws_kms_alias.sns.name
 }
 
 resource "aws_ses_identity_notification_topic" "platform_mvp_ses_bounce_topic" {
   topic_arn                = aws_sns_topic.platform_mvp_ses.arn
   notification_type        = "Bounce"
-  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.arn
   include_original_headers = false
 }
 
 resource "aws_ses_identity_notification_topic" "cplatform_mvp_ses_delivery_topic" {
   topic_arn                = aws_sns_topic.platform_mvp_ses.arn
   notification_type        = "Delivery"
-  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.arn
   include_original_headers = false
 }
 
 resource "aws_ses_identity_notification_topic" "platform_mvp_ses_complaint_topic" {
   topic_arn                = aws_sns_topic.platform_mvp_ses.arn
   notification_type        = "Complaint"
-  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.domain
+  identity                 = aws_ses_domain_identity.platform_mvp_sending_domain.arn
   include_original_headers = false
 }
 


### PR DESCRIPTION
# Summary
Attempting to use the SNS service key stopped the SES notification topics from using the SNS topic.

Note, this was applied locally to test, so there should be no planned changes.