### PR TITLE
feat: add SPF and DMARC validation DNS records

### DIFF
--- a/infrastructure/terragrunt/aws/ses/inputs.tf
+++ b/infrastructure/terragrunt/aws/ses/inputs.tf
@@ -1,9 +1,24 @@
+variable "dmarc_policy" {
+  description = "DMARC policy action to take for emails that fail authentication"
+  type        = string
+
+  validation {
+    condition     = contains(["none", "quarantine", "reject"], var.dmarc_policy)
+    error_message = "Valid values for var: dmarc_policy are: none, quarantine, reject."
+  }
+}
+
+variable "dmarc_report_email" {
+  description = "DMARC destination email address for reports of emails that failed authentication"
+  type        = string
+}
+
 variable "route53_zone_id" {
   description = "Route53 zone to create the SES verification and DKIM records in"
   type        = string
 }
 
 variable "ses_sending_domain" {
-  description = "Domain that will be used by SES to send emails from."
+  description = "Domain that will be used by SES to send emails from"
   type        = string
 }

--- a/infrastructure/terragrunt/aws/ses/route53.tf
+++ b/infrastructure/terragrunt/aws/ses/route53.tf
@@ -21,3 +21,40 @@ resource "aws_route53_record" "platform_mvp_ses_verification" {
   ttl     = "600"
   records = [aws_ses_domain_identity.platform_mvp_sending_domain.verification_token]
 }
+
+# SPF validation record
+# https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-spf.html
+resource "aws_route53_record" "platform_mvp_spf_mail_from" {
+  zone_id = var.route53_zone_id
+  name    = aws_ses_domain_mail_from.platform_mvp_domain_mail_from.mail_from_domain
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+resource "aws_route53_record" "platform_mvp_spf_domain" {
+  zone_id = var.route53_zone_id
+  name    = var.ses_sending_domain
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# Sending MX Record
+resource "aws_route53_record" "platform_mvp_mx_send_mail_from" {
+  zone_id = var.route53_zone_id
+  name    = aws_ses_domain_mail_from.platform_mvp_domain_mail_from.mail_from_domain
+  type    = "MX"
+  ttl     = "600"
+  records = ["10 feedback-smtp.${var.region}.amazonses.com"]
+}
+
+# DMARC Record
+# https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dmarc.html
+resource "aws_route53_record" "platform_mvp_dmarc" {
+  zone_id = var.route53_zone_id
+  name    = "_dmarc.${var.ses_sending_domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=DMARC1; p=${var.dmarc_policy}; rua=mailto:${var.dmarc_report_email};"]
+}

--- a/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
@@ -17,6 +17,8 @@ dependency "cloudfront" {
 }
 
 inputs = {
+  dmarc_policy       = "none"
+  dmarc_report_email = "platform+platform-cms@cds-snc.ca"
   route53_zone_id    = dependency.cloudfront.outputs.route53_zone_id
   ses_sending_domain = dependency.cloudfront.outputs.domain_name
 }


### PR DESCRIPTION
# Summary
This creates the SPF validation records and DMARC authentication record used to improve the behaviour of sending email through SES.

# Expected resources
4 new DNS records