### PR TITLE
fix: update DMARC policy to send to CCCS

### DIFF
--- a/infrastructure/terragrunt/aws/ses/route53.tf
+++ b/infrastructure/terragrunt/aws/ses/route53.tf
@@ -56,5 +56,5 @@ resource "aws_route53_record" "platform_mvp_dmarc" {
   name    = "_dmarc.${var.ses_sending_domain}"
   type    = "TXT"
   ttl     = "600"
-  records = ["v=DMARC1; p=${var.dmarc_policy}; rua=mailto:${var.dmarc_report_email};"]
+  records = ["v=DMARC1; p=${var.dmarc_policy}; sp=${var.dmarc_policy}; pct=100; rua=mailto:${var.dmarc_report_email};"]
 }

--- a/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
+++ b/infrastructure/terragrunt/env/dev/ses/terragrunt.hcl
@@ -17,8 +17,8 @@ dependency "cloudfront" {
 }
 
 inputs = {
-  dmarc_policy       = "none"
-  dmarc_report_email = "platform+platform-cms@cds-snc.ca"
+  dmarc_policy       = "reject"
+  dmarc_report_email = "dmarc@cyber.gc.ca"
   route53_zone_id    = dependency.cloudfront.outputs.route53_zone_id
   ses_sending_domain = dependency.cloudfront.outputs.domain_name
 }


### PR DESCRIPTION
# Summary
Canadian Centre for Cyber Security (CCCS) will now process failed DMARC authentication for email sending.

# Expected changes
Update DMARC DNS record.