### PR TITLE
Add composer install on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This project is configured to use [Composer](https://getcomposer.org/) to manage
 
 To install a plugin or theme, find it on [WPackagist](https://wpackagist.org/), add it to composer.json, and run `composer install` or use `composer require [package-name]`. These commands should be run from within the `wordpress` folder.
 
+Note: when starting up the devcontainer or docker-compose, `composer install` is run to automatically install plugins and themes defined in composer.json.
+
 ### Creating
 
 When creating a custom plugin or theme, you should prefix the folder name with `cds-`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,13 @@ services:
     networks:
       - app-network
 
+  composer:
+    restart: 'no'
+    image: composer/composer:latest
+    command: install
+    volumes:
+      - ./wordpress:/app
+
   cli:
     container_name: cli
     depends_on:
@@ -87,7 +94,7 @@ services:
     restart: unless-stopped
     networks:
       - app-network
-    
+
 volumes:
   wordpress:
   dbdata:


### PR DESCRIPTION
# Summary | Résumé

Adds a composer install action on docker-compose startup. Meaning, when you bring up the devcontainer or run `docker-compose up`, `composer install` will automatically run and pull in any installed themes/plugins.