### PR TITLE
Add theme to redirect to sandbox site

### DIFF
--- a/wordpress/wp-content/themes/cds-sandbox-redirector/index.php
+++ b/wordpress/wp-content/themes/cds-sandbox-redirector/index.php
@@ -1,0 +1,16 @@
+<?php
+// Redirects all requests to the platform.cdssandbox.xyz.  
+// Primarily used to redirect preview links from WP Admin
+
+
+global $wp;
+$host = $_SERVER['HTTP_HOST'];
+$redirectHost = "platform.cdssandbox.xyz";
+$homeUrl = home_url( $wp->request );
+
+$search = array($host, 'http://');
+$replace = array($redirectHost, 'https://');
+
+$redirectUrl = str_replace($search, $replace, $homeUrl);
+
+header("Location: $redirectUrl");

--- a/wordpress/wp-content/themes/cds-sandbox-redirector/style.css
+++ b/wordpress/wp-content/themes/cds-sandbox-redirector/style.css
@@ -1,0 +1,10 @@
+/*!
+Theme Name: Sandbox Redirector
+Theme URI: https://github.com/cds-snc/platform-mvp
+Author: Tim Arney
+Author URI: https://github.com/cds-snc/platform-mvp
+Description: Redirects all requests to the platform.cdssandbox.xyz.  Primarily used to redirect preview links from WP Admin
+Version: 1.0.0
+Text Domain: sandbox-redirector
+*/
+


### PR DESCRIPTION
Default theme which will redirect preview links etc... to the sandbox domain / Frontity site i.e. the site deployed from https://github.com/cds-snc/platform-mvp/tree/main/front-end-server vs the WP Admin site.

Noting the theme will need to be activated for each site.