### PR TITLE
Add and enable smtp plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       wp theme enable cds-default --activate;
       wp plugin activate cds-base --network;
       wp plugin activate oasis-workflow --network;
+      wp plugin activate wp-mail-smtp --network;
       '
     volumes:
       - wordpress:/var/www/html

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -7,7 +7,8 @@
     ],
     "require": {
         "wpackagist-plugin/wp-rest-api-v2-menus": "^0.10.0",
-        "wpackagist-plugin/oasis-workflow": "^5.7"
+        "wpackagist-plugin/oasis-workflow": "^5.7",
+        "wpackagist-plugin/wp-mail-smtp": "^3.0"
     },
     "require-dev": {
         "nunomaduro/phpinsights": "^2.0"

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2e964b439871dc3c9e1f28069cd9b83",
+    "content-hash": "ab8ef1b9a64f3921f287e54618c37dde",
     "packages": [
         {
             "name": "composer/installers",
@@ -173,6 +173,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/oasis-workflow/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-mail-smtp",
+            "version": "3.0.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
+                "reference": "tags/3.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.3.0.3.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-mail-smtp/"
         },
         {
             "name": "wpackagist-plugin/wp-rest-api-v2-menus",
@@ -1509,20 +1527,20 @@
         },
         {
             "name": "psr/cache",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
+                "reference": "213f9dbc5b9bfbc4f8db86d2838dc968752ce13b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
@@ -1542,7 +1560,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for caching libraries",
@@ -1552,9 +1570,9 @@
                 "psr-6"
             ],
             "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
+                "source": "https://github.com/php-fig/cache/tree/2.0.0"
             },
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2021-02-03T23:23:37+00:00"
         },
         {
             "name": "psr/container",
@@ -3935,5 +3953,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/wordpress/phpinsights.php
+++ b/wordpress/phpinsights.php
@@ -59,6 +59,7 @@ return [
         'wp-content/plugins/wp-rest-api-v2-menus',
         'wp-content/plugins/hello.php',
         'wp-content/plugins/oasis-workflow',
+        'wp-content/plugins/wp-mail-smtp',
     ],
 
     'add' => [


### PR DESCRIPTION
# Summary | Résumé

Adds and enables `wp-smtp-mail` plugin
