### PR TITLE
Set default permalink config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       /bin/bash -c '
       sleep 10;
       wp core multisite-install --path="/var/www/html" --url="localhost:${WEB_PORT}" --title="CDS Wordpress Base" --admin_user=${ADMIN_USER} --admin_password=${ADMIN_PASSWORD} --admin_email=${ADMIN_EMAIL};
+      wp option update permalink_structure "/%postname%/";
       wp theme enable cds-default --activate;
       wp plugin activate cds-base --network;
       wp plugin activate oasis-workflow --network;


### PR DESCRIPTION
# Summary | Résumé

Sets the default permalink config to: `/%postname%/`

This resolves to `/site-name/post-name` for subsites.