### PR TITLE
CLI container experience improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,8 @@ WORKDIR $HOME
 # Oh-my-zsh
 RUN sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
 RUN echo "source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ~/.zshrc && \
-    echo "source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc
+    echo "source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc && \
+    echo "PROMPT=\"(devcontainer) \$PROMPT\"" >> ~/.zshrc
 
 ENV SHELL /bin/zsh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,8 @@ services:
       - wordpress:/var/www/html
       - ./wordpress/wp-content:/var/www/html/wp-content
       - ./:/home/default/project
+      - ~/.ssh:/home/default/.ssh
+      - ~/.gitconfig:/home/default/.gitconfig
     restart: unless-stopped
     networks:
       - app-network


### PR DESCRIPTION
# Summary | Résumé

Adds a little visual hint for when you are in the cli container terminal to distinguish it from your host terminal:

![image](https://user-images.githubusercontent.com/1187115/129968942-eb29f152-ab2a-49b2-9f87-f1824540cc99.png)

Also shares the host `~/.ssh` and `~/.gitconfig` with the container so that you can run git commands within.

You may see the following error when running git commands:

![image](https://user-images.githubusercontent.com/1187115/129970421-be6a96ab-7d65-4cfa-98d9-a60599b88e0b.png)

In this case, you should update your `~/.ssh/config` to include `IgnoreUnknown UseKeychain` like so:

![image](https://user-images.githubusercontent.com/1187115/129970673-a2564463-3278-4a26-bcd9-ba36c13cdef0.png)

(Your IdentityFile might be different)

## To test

If you're already running the environment, shut it down and bring it back up with the build flag:

```
docker-compose up --build
```

Alternatively, you can just start up the cli container:

```
docker-compose up --build cli
```

Then you should ssh into the container:

```
docker exec -it cli /bin/zsh
```

You should see the prefixed zsh prompt. And if you cd into the project folder you should be able to git push without error:

```
cd project
git push
```

![image](https://user-images.githubusercontent.com/1187115/129971495-63fe1d92-5210-46c4-b1c6-d54a38002d87.png)
