### PR TITLE
Theme Date filter + Post Navigation styling

### DIFF
--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -9,9 +9,7 @@
         "wpackagist-plugin/wp-rest-api-v2-menus": "^0.10.0",
         "wpackagist-plugin/oasis-workflow": "^5.7",
         "wpackagist-plugin/wp-mail-smtp": "^3.0",
-        "wpackagist-plugin/wordpress-importer": "^0.7.0"
-    },
-    "require-dev": {
+        "wpackagist-plugin/wordpress-importer": "^0.7.0",
         "nunomaduro/phpinsights": "^2.0"
     }
 }

--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -65,17 +65,17 @@ function cds_register_block(): void
     register_block_style(
         'core/table',
         [
-              'name' => 'filterable',
-              'label' => 'Filterable Table',
-          ]
+            'name' => 'filterable',
+            'label' => 'Filterable Table',
+        ]
     );
 
     register_block_style(
         'core/table',
         [
-              'name' => 'responsive-cards',
-              'label' => 'Responsive Cards Table',
-          ]
+            'name' => 'responsive-cards',
+            'label' => 'Responsive Cards Table',
+        ]
     );
 
     if (function_exists('wp_set_script_translations')) {

--- a/wordpress/wp-content/plugins/cds-base/index.php
+++ b/wordpress/wp-content/plugins/cds-base/index.php
@@ -63,20 +63,20 @@ function cds_register_block(): void
     );
 
     register_block_style(
-          'core/table',
-          [
-            'name' => 'filterable',
-            'label' => 'Filterable Table',
-        ]
-      );
+        'core/table',
+        [
+              'name' => 'filterable',
+              'label' => 'Filterable Table',
+          ]
+    );
 
     register_block_style(
-          'core/table',
-          [
-            'name' => 'responsive-cards',
-            'label' => 'Responsive Cards Table',
-        ]
-      );
+        'core/table',
+        [
+              'name' => 'responsive-cards',
+              'label' => 'Responsive Cards Table',
+          ]
+    );
 
     if (function_exists('wp_set_script_translations')) {
         /**

--- a/wordpress/wp-content/themes/cds-default/archive.php
+++ b/wordpress/wp-content/themes/cds-default/archive.php
@@ -37,7 +37,7 @@ get_header();
                 get_template_part('template-parts/content', get_post_type());
             }
 
-            the_posts_navigation();
+            cds_the_posts_navigation();
 
         } else {
             get_template_part('template-parts/content', 'none');

--- a/wordpress/wp-content/themes/cds-default/composer.json
+++ b/wordpress/wp-content/themes/cds-default/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "paquettg/php-html-parser": "^3.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/wordpress/wp-content/themes/cds-default/composer.lock
+++ b/wordpress/wp-content/themes/cds-default/composer.lock
@@ -4,8 +4,688 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8de789a2c20183752e72c14c93a923cf",
-    "packages": [],
+    "content-hash": "16117cf6f0e5c7a35d28a622586a16dc",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+            },
+            "time": "2021-04-26T09:17:50+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "b942d263c641ddb5190929ff840c68f78713e937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/b942d263c641ddb5190929ff840c68f78713e937",
+                "reference": "b942d263c641ddb5190929ff840c68f78713e937",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^4.6.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/php-enum/issues",
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-05T08:18:36+00:00"
+        },
+        {
+            "name": "paquettg/php-html-parser",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paquettg/php-html-parser.git",
+                "reference": "4e01a438ad5961cc2d7427eb9798d213c8a12629"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paquettg/php-html-parser/zipball/4e01a438ad5961cc2d7427eb9798d213c8a12629",
+                "reference": "4e01a438ad5961cc2d7427eb9798d213c8a12629",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "guzzlehttp/guzzle": "^7.0",
+                "guzzlehttp/psr7": "^1.6",
+                "myclabs/php-enum": "^1.7",
+                "paquettg/string-encode": "~1.0.0",
+                "php": ">=7.2",
+                "php-http/httplug": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "infection/infection": "^0.13.4",
+                "mockery/mockery": "^1.2",
+                "phan/phan": "^2.4",
+                "phpunit/phpunit": "^7.5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPHtmlParser\\": "src/PHPHtmlParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gilles Paquette",
+                    "email": "paquettg@gmail.com",
+                    "homepage": "http://gillespaquette.ca"
+                }
+            ],
+            "description": "An HTML DOM parser. It allows you to manipulate HTML. Find tags on an HTML page with selectors just like jQuery.",
+            "homepage": "https://github.com/paquettg/php-html-parser",
+            "keywords": [
+                "dom",
+                "html",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/paquettg/php-html-parser/issues",
+                "source": "https://github.com/paquettg/php-html-parser/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/paquettg/php-html-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-01T20:34:43+00:00"
+        },
+        {
+            "name": "paquettg/string-encode",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paquettg/string-encoder.git",
+                "reference": "a8708e9fac9d5ddfc8fc2aac6004e2cd05d80fee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paquettg/string-encoder/zipball/a8708e9fac9d5ddfc8fc2aac6004e2cd05d80fee",
+                "reference": "a8708e9fac9d5ddfc8fc2aac6004e2cd05d80fee",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "stringEncode": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gilles Paquette",
+                    "email": "paquettg@gmail.com",
+                    "homepage": "http://gillespaquette.ca"
+                }
+            ],
+            "description": "Facilitating the process of altering string encoding in PHP.",
+            "homepage": "https://github.com/paquettg/string-encoder",
+            "keywords": [
+                "charset",
+                "encoding",
+                "string"
+            ],
+            "support": {
+                "issues": "https://github.com/paquettg/string-encoder/issues",
+                "source": "https://github.com/paquettg/string-encoder/tree/1.0.1"
+            },
+            "time": "2018-12-21T02:25:09+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1",
+                "phpspec/phpspec": "^5.1 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/httplug/issues",
+                "source": "https://github.com/php-http/httplug/tree/master"
+            },
+            "time": "2020-07-13T15:43:23+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
+                "phpspec/phpspec": "^5.1.2 || ^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/promise/issues",
+                "source": "https://github.com/php-http/promise/tree/1.1.0"
+            },
+            "time": "2020-07-07T09:29:14+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1196,5 +1876,5 @@
         "php": ">=5.6"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+require __DIR__ . '/vendor/autoload.php';
+require_once(__DIR__."/inc/template-filters.php");
+
 /**
  * cds-default functions and definitions
  *

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
-require_once(__DIR__."/inc/template-filters.php");
+require_once __DIR__.'/inc/template-filters.php';
 
 /**
  * cds-default functions and definitions

--- a/wordpress/wp-content/themes/cds-default/inc/template-filters.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-filters.php
@@ -21,3 +21,13 @@ function cds_date_block($block_content, $block)
         return $block_content;
     }
 }
+
+// define the navigation_markup_template callback
+function filter_navigation_markup_template($template, $class)
+{
+    // make filter magic happen here...
+    $output = '<nav class="navigation 1 %1$s mrgn-tp-xl" role="navigation" aria-label="%4$s">';
+    $output .= '<ul class="pager">%3$s</ul>';
+    $output .= '</nav>';
+    return $output;
+}

--- a/wordpress/wp-content/themes/cds-default/inc/template-filters.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-filters.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use PHPHtmlParser\Dom;
+
+add_filter( 'render_block', 'cds_date_block', 10, 3);
+ 
+function cds_date_block( $block_content, $block ) {
+     
+  if( "core/post-date" !== $block['blockName'] ) {
+    return $block_content;
+  }
+
+  try{
+      $dom = new Dom;
+      $dom->loadStr($block_content);
+      $time = $dom->find('time')[0];
+      return str_replace($time, "[".$time."]", $block_content);
+  }catch(Exception $e){
+      return $block_content;
+  }
+
+}

--- a/wordpress/wp-content/themes/cds-default/inc/template-filters.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-filters.php
@@ -1,23 +1,23 @@
 <?php
+
 declare(strict_types=1);
 
 use PHPHtmlParser\Dom;
 
-add_filter( 'render_block', 'cds_date_block', 10, 3);
- 
-function cds_date_block( $block_content, $block ) {
-     
-  if( "core/post-date" !== $block['blockName'] ) {
-    return $block_content;
-  }
+add_filter('render_block', 'cds_date_block', 10, 3);
 
-  try{
-      $dom = new Dom;
-      $dom->loadStr($block_content);
-      $time = $dom->find('time')[0];
-      return str_replace($time, "[".$time."]", $block_content);
-  }catch(Exception $e){
-      return $block_content;
-  }
+function cds_date_block($block_content, $block)
+{
+    if ($block['blockName'] !== 'core/post-date') {
+        return $block_content;
+    }
 
+    try {
+        $dom = new Dom();
+        $dom->loadStr($block_content);
+        $time = $dom->find('time')[0];
+        return str_replace($time, '['.$time.']', $block_content);
+    } catch (Exception $e) {
+        return $block_content;
+    }
 }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -87,3 +87,42 @@ function cds_category_links($post_id, $separator = ','): string
 
     return $list;
 }
+
+function cds_the_posts_navigation($args = []): void
+{
+    $navigation = '';
+
+    // Don't print empty markup if there's only one page.
+    if ($GLOBALS['wp_query']->max_num_pages > 1) {
+        // Make sure the nav element has an aria-label attribute: fallback to the screen reader text.
+        if (! empty($args['screen_reader_text']) && empty($args['aria_label'])) {
+            $args['aria_label'] = $args['screen_reader_text'];
+        }
+
+        $args = wp_parse_args(
+            $args,
+            [
+                'prev_text' => __('Older posts'),
+                'next_text' => __('Newer posts'),
+                'screen_reader_text' => __('Posts navigation'),
+                'aria_label' => __('Posts'),
+                'class' => 'posts-navigation',
+            ]
+        );
+
+        $next_link = get_previous_posts_link($args['next_text']);
+        $prev_link = get_next_posts_link($args['prev_text']);
+
+        if ($prev_link) {
+            $navigation .= '<li class="previous">' . $prev_link . '</li>';
+        }
+
+        if ($next_link) {
+            $navigation .= '<li class="next">' . $next_link . '</li>';
+        }
+
+        $navigation = _navigation_markup($navigation, $args['class'], $args['screen_reader_text'], $args['aria_label']);
+    }
+
+    echo $navigation;
+}

--- a/wordpress/wp-content/themes/cds-default/inc/template-tags.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-tags.php
@@ -101,7 +101,7 @@ if (! function_exists('cds_post_thumbnail')) {
             ?>
 
             <div class="post-thumbnail">
-                <?php the_post_thumbnail("full",  ['class' => 'img-responsive full-width']); ?>
+                <?php the_post_thumbnail('full', ['class' => 'img-responsive full-width']); ?>
             </div><!-- .post-thumbnail -->
 
         <?php
@@ -117,7 +117,7 @@ if (! function_exists('cds_post_thumbnail')) {
                             'echo' => false,
                         ]
                     ),
-                    'class' => 'img-responsive thumbnail'
+                    'class' => 'img-responsive thumbnail',
                 ]
             );
                 ?>

--- a/wordpress/wp-content/themes/cds-default/index.php
+++ b/wordpress/wp-content/themes/cds-default/index.php
@@ -42,7 +42,7 @@ get_header();
                 get_template_part('template-parts/content', get_post_type());
             }
 
-            the_posts_navigation();
+            cds_the_posts_navigation();
         } else {
             get_template_part('template-parts/content', 'none');
         }

--- a/wordpress/wp-content/themes/cds-default/search.php
+++ b/wordpress/wp-content/themes/cds-default/search.php
@@ -39,7 +39,7 @@ get_header();
                 get_template_part('template-parts/content', 'search');
             }
 
-            the_posts_navigation();
+            cds_the_posts_navigation();
 
         } else {
             get_template_part('template-parts/content', 'none');

--- a/wordpress/wp-content/themes/cds-default/template-parts/content.php
+++ b/wordpress/wp-content/themes/cds-default/template-parts/content.php
@@ -29,19 +29,19 @@ declare(strict_types=1);
         <?php
          if (is_singular()) {
              the_content(
-                sprintf(
+                 sprintf(
                     wp_kses(
                     /* translators: %s: Name of current post. Only visible to screen readers */
                     __('Continue reading<span class="screen-reader-text"> "%s"</span>', 'cds'),
-                            [
-                        'span' => [
-                            'class' => [],
-                        ],
-                    ]
-                        ),
+                        [
+                                'span' => [
+                                    'class' => [],
+                                ],
+                            ]
+                    ),
                     wp_kses_post(get_the_title())
                 )
-            );
+             );
          } else {
              wp_trim_excerpt(the_excerpt());
          }

--- a/wordpress/wp-content/themes/cds-default/template-parts/content.php
+++ b/wordpress/wp-content/themes/cds-default/template-parts/content.php
@@ -30,17 +30,17 @@ declare(strict_types=1);
          if (is_singular()) {
              the_content(
                  sprintf(
-                    wp_kses(
+                     wp_kses(
                     /* translators: %s: Name of current post. Only visible to screen readers */
                     __('Continue reading<span class="screen-reader-text"> "%s"</span>', 'cds'),
-                        [
-                                'span' => [
-                                    'class' => [],
-                                ],
-                            ]
-                    ),
-                    wp_kses_post(get_the_title())
-                )
+                         [
+                            'span' => [
+                                'class' => [],
+                            ],
+                        ]
+                     ),
+                     wp_kses_post(get_the_title())
+                 )
              );
          } else {
              wp_trim_excerpt(the_excerpt());


### PR DESCRIPTION
## Dates 

Dates on this site https://blog.canada.ca/ are wrapped in [ ] i.e. [your_date]

**Example:**
<img width="417" alt="Screen Shot 2021-08-19 at 10 49 40 AM" src="https://user-images.githubusercontent.com/62242/130090670-393dfdae-f7e0-414c-8e50-7b56443b6114.png">

This PR add a WP filter to modify the HTML output of the Post Date Block 

<img width="732" alt="Screen Shot 2021-08-19 at 10 50 44 AM" src="https://user-images.githubusercontent.com/62242/130090808-62b2413c-b7b0-4f9e-a4b3-65c678a378d7.png">

## Testing

- Using the cds-default theme insert `Post Date` block 
- View the resulting output to ensure [your_date] output of the date

<img width="429" alt="Screen Shot 2021-08-19 at 10 56 12 AM" src="https://user-images.githubusercontent.com/62242/130091454-d5612ed2-6a02-4847-8fee-d96805fcc311.png">

<hr>

## Post Navigation

This PR also updates the post navigation output which was previously using different markup and ending up unstyled. 

**Before**

<img width="384" alt="Screen Shot 2021-08-19 at 12 42 42 PM" src="https://user-images.githubusercontent.com/62242/130109316-4500cdbc-c63a-4b60-b649-bbd34c1916a3.png">


**After**
<img width="1081" alt="Screen Shot 2021-08-19 at 12 33 43 PM" src="https://user-images.githubusercontent.com/62242/130109078-85e4f4a4-df75-40ac-b8f9-aecf5c786ac2.png">





