### PR TITLE
Updates to initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # platform-mvp
 
-Stay tuned ...
-
 ## Local dev
 
 Docker-compose and VS Code Remote Container environment featuring:
@@ -12,9 +10,10 @@ Docker-compose and VS Code Remote Container environment featuring:
   - phpmyadmin (db admin)
 
 ## Requirements
+- NPM
 - Docker
 - Docker-compose
-- VS Code w/ Remote Containers extension
+- VS Code w/ Remote Containers extension (optional)
 
 ## Config
 
@@ -26,10 +25,38 @@ cp .env.example .env
 
 ## Usage
 
+To start, clone the repo and then run NPM install:
+
+```
+git clone git@github.com:cds-snc/platform-mvp.git
+cd platform-mvp
+npm i
+```
+
+Then you can bring up the environment using docker-compose:
+
+```
+docker-compose up
+```
+
+Once the services are running, you can access a cli environment preconfigured with all the tools needed for development:
+
+```
+npm run cli
+```
+
+Alternatively, you can open the project in VS Code Remote Containers:
+
 - Open the project in VS Code
 - When prompted "Reopen in container" or press F1 -> Remote-Containers: Open folder in container
-- Visit `localhost:8000` to see your new WordPress install
-- Visit `localhost:8000/wp-admin` to see the admin interface
+- VS Code will open a devcontainer terminal environment
+
+### Access WordPress
+
+Either way, once the environment is up, the site will be available on `localhost`:
+
+- Visit `localhost` to see your new WordPress install
+- Visit `localhost/wp-admin` to see the admin interface
 
 Wordpress will be installed with some pre-configured plugins and themes, and will be configured as a multi-site install. There will also be a default administrator account, with the following credentials:
 
@@ -51,6 +78,12 @@ Web interface: `localhost:8080`
 
 ## Plugins and Themes
 
+Pre-installed plugins:
+- [oasis-workflow](https://www.oasisworkflow.com/)
+- [wordpress-importer](https://wordpress.org/plugins/wordpress-importer/)
+- [wp-mail-smtp](https://wordpress.org/plugins/wp-mail-smtp/)
+- [wp-rest-api-v2-menus](https://wordpress.org/plugins/wp-rest-api-v2-menus/)
+
 ### Installing
 This project is configured to use [Composer](https://getcomposer.org/) to manage [WordPress Themes and Plugins](https://www.smashingmagazine.com/2019/03/composer-wordpress/). 
 
@@ -60,4 +93,4 @@ Note: when starting up the devcontainer or docker-compose, `composer install` is
 
 ### Creating
 
-When creating a custom plugin or theme, you should prefix the folder name with `cds-`.
+When creating a custom plugin or theme, you should prefix the folder name with `cds-`. This will ensure the code is included in git and code quality scans.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pre-installed plugins:
 ### Installing
 This project is configured to use [Composer](https://getcomposer.org/) to manage [WordPress Themes and Plugins](https://www.smashingmagazine.com/2019/03/composer-wordpress/). 
 
-To install a plugin or theme, find it on [WPackagist](https://wpackagist.org/), add it to composer.json, and run `composer install` or use `composer require [package-name]`. These commands should be run from within the `wordpress` folder.
+To install a plugin or theme, find it on [WPackagist](https://wpackagist.org/), add it to composer.json, and run `composer install` or use `composer require wpackagist-[plugin|theme]/[package-name]`. These commands should be run from within the `wordpress` folder.
 
 Note: when starting up the devcontainer or docker-compose, `composer install` is run to automatically install plugins and themes defined in composer.json.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,17 +131,6 @@ services:
     networks:
       - app-network
 
-  build-plugin:
-    container_name: build-plugin
-    restart: 'no'
-    image: node:slim
-    volumes:
-      - ./:/home/default/project
-    working_dir: /home/default/project/wordpress/wp-content/plugins/cds-base
-    command: >
-      bash -c "npm i
-      && npm run build"
-
 volumes:
   wordpress:
   dbdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+    "name": "platform-mvp",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "platform-mvp",
+            "hasInstallScript": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-    "name": "deploy",
+    "name": "platform-mvp",
     "scripts": {
       "deploy-plugin": "./deploy/plugin",
-      "deploy-theme": "./deploy/theme"
+      "deploy-theme": "./deploy/theme",
+      "cli": "docker exec -it cli /bin/zsh",
+      "postinstall": "cd wordpress/wp-content/plugins/cds-base && npm install && npm run build"
     }
   }
   

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -13,5 +13,8 @@
     },
     "require-dev": {
         "nunomaduro/phpinsights": "^2.0"
+    },
+    "scripts": {
+        "post-install-cmd": "cd wp-content/themes/cds-default && composer install"
     }
 }


### PR DESCRIPTION
# Summary | Résumé

The NPM install step in docker-compose was running too late on clean installs, and there wasn't a great way to wait for it to run (this is a different issue than waiting for the db service to be ready).

To ensure that the cds-base plugin is compiled and ready for install, we're going to add a build step before bringing up the environment.

Additionally, there is some work happening in another PR that introduces a composer dependency to the cds-default theme, so also included here is an update to the existing wordpress/composer.json that will recursively install the theme-related dependencies.

Finally, the README has been updated to reflect these changes.
