### PR TITLE
Setup xdebug

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:cli
+FROM wordpress:cli-php8.0
 
 # ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 USER root

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+			"pathMappings": {
+				"/var/www/html/wp-content/themes/cds-default": "${workspaceRoot}/wordpress/wp-content/themes/cds-default"
+			}
+        }
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
   wordpress:
     depends_on:
       - db
-    # image: wordpress:5.8.0-php8.0-apache
     build:
       dockerfile: Dockerfile
       context: ./wordpress/docker
@@ -42,8 +41,8 @@ services:
       - wordpress:/var/www/html
       - ./wordpress/wp-content:/var/www/html/wp-content
       - ./wordpress/.htaccess-multisite:/var/www/html/.htaccess
-      # - ./wordpress/docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-      # - ./wordpress/docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
+      - ./wordpress/docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./wordpress/docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,10 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:latest
+    # image: wordpress:5.8.0-php8.0-apache
+    build:
+      dockerfile: Dockerfile
+      context: ./wordpress/docker
     container_name: wordpress
     restart: always
     ports:
@@ -39,6 +42,8 @@ services:
       - wordpress:/var/www/html
       - ./wordpress/wp-content:/var/www/html/wp-content
       - ./wordpress/.htaccess-multisite:/var/www/html/.htaccess
+      # - ./wordpress/docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      # - ./wordpress/docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
     networks:
       - app-network
 
@@ -72,7 +77,7 @@ services:
     depends_on:
       - db
       - wordpress
-    image: wordpress:cli
+    image: wordpress:cli-php8.0
     env_file: .env
     environment:
       WORDPRESS_CONFIG_EXTRA: |

--- a/wordpress/docker/Dockerfile
+++ b/wordpress/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM wordpress:5.8.0-php8.0-apache
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug

--- a/wordpress/docker/php/conf.d/error_reporting.ini
+++ b/wordpress/docker/php/conf.d/error_reporting.ini
@@ -1,0 +1,1 @@
+error_reporting=E_ALL

--- a/wordpress/docker/php/conf.d/xdebug.ini
+++ b/wordpress/docker/php/conf.d/xdebug.ini
@@ -1,0 +1,6 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes

--- a/wordpress/docker/php/conf.d/xdebug.ini
+++ b/wordpress/docker/php/conf.d/xdebug.ini
@@ -4,3 +4,5 @@ zend_extension=xdebug
 xdebug.mode=develop,debug
 xdebug.client_host=host.docker.internal
 xdebug.start_with_request=yes
+
+xdebug.client_port=9003


### PR DESCRIPTION
# Summary | Résumé

Configures the wordpress container with XDebug and adds vscode launch.json config. Also updates all our php containers to PHP8.

## To use XDebug:
- Install a browser helper extension, for example [this one for Chrome](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc)
- Ensure your IDE is configured (see below)
- Restart the dev environment with the build flag: `docker-compose up --build`
- Enable debugging in the browser extension
- Set a breakpoint
- Reload localhost

## IDE Configuration

### PHPStorm
In Preferences -> Languages & Frameworks -> PHP -> Debug
- Ensure Debug port is set to 9003
- Set "Break at first line in PHP scripts" (or just set a breakpoint somewhere)

In Preferences -> Languages & Frameworks -> PHP -> Servers
- Configure a folder mapping your local wp-content to the wp-content in the container:
![image](https://user-images.githubusercontent.com/1187115/130259286-8f2e93d9-c414-4af9-a3c5-94bf7750ab11.png)

### VSCode
You will need this [VS Code PHP Debug extension](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug)
Necessary configuration is contained in `.vscode/launch.json` should be good to go, just open the debug tab and click "Listen for Xdebug" 

![image](https://user-images.githubusercontent.com/1187115/130259726-bdd2f9b3-1efc-48e7-bde5-bff2544691d3.png)
