### PR TITLE
Breadcrumb nav

### DIFF
--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -99,3 +99,25 @@ require get_template_directory() . '/inc/template-tags.php';
  * Functions which enhance the theme by hooking into WordPress.
  */
 require get_template_directory() . '/inc/template-functions.php';
+
+function the_crumb($crumb, $sep = "")
+{
+    //if (preg_match('/\\<span\\40class=\\"breadcrumb_last\\"/\', $crumb)) {
+        
+    //}
+
+    return '<li>' . $crumb . ' <span class="divider">' . $sep . '</span></li>';
+}
+
+function the_breadcrumbs($sep = '')
+{
+    if (!function_exists('yoast_breadcrumb')) {
+        return null;
+    }
+    // Default Yoast Breadcrumbs Separator
+    //  $old_sep = '\&raquo\;';
+    $old_sep = '»';
+    // Get the crumbs
+    echo $crumbs = yoast_breadcrumb( '<div id="breadcrumbs">','</div>' );
+    
+}

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -6,7 +6,6 @@ require __DIR__ . '/vendor/autoload.php';
 require_once __DIR__. '/inc/template-functions.php';
 require_once __DIR__.'/inc/template-filters.php';
 
-
 /**
  * cds-default functions and definitions
  *

--- a/wordpress/wp-content/themes/cds-default/functions.php
+++ b/wordpress/wp-content/themes/cds-default/functions.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__. '/inc/template-functions.php';
 require_once __DIR__.'/inc/template-filters.php';
+
 
 /**
  * cds-default functions and definitions
@@ -94,30 +96,3 @@ add_action('wp_enqueue_scripts', 'cds_scripts');
  * Custom template tags for this theme.
  */
 require get_template_directory() . '/inc/template-tags.php';
-
-/**
- * Functions which enhance the theme by hooking into WordPress.
- */
-require get_template_directory() . '/inc/template-functions.php';
-
-function the_crumb($crumb, $sep = "")
-{
-    //if (preg_match('/\\<span\\40class=\\"breadcrumb_last\\"/\', $crumb)) {
-        
-    //}
-
-    return '<li>' . $crumb . ' <span class="divider">' . $sep . '</span></li>';
-}
-
-function the_breadcrumbs($sep = '')
-{
-    if (!function_exists('yoast_breadcrumb')) {
-        return null;
-    }
-    // Default Yoast Breadcrumbs Separator
-    //  $old_sep = '\&raquo\;';
-    $old_sep = '»';
-    // Get the crumbs
-    echo $crumbs = yoast_breadcrumb( '<div id="breadcrumbs">','</div>' );
-    
-}

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -96,24 +96,9 @@ declare(strict_types=1);
                 </ul>
             </div>
         </nav>
-        <nav id="wb-bc" property="breadcrumb">
-            <h2>You are here:</h2>
-            <div class="container">
-                <ol class="breadcrumb">
-                    <li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>
-                </ol>
-
-                
-            </div>
-        </nav>
-        <nav id="wb-bc" property="breadcrumb">
-        <div class="container">
-        <h2><?php _e("You are here:"); ?></h2>
+       
+       
         <?php
-        
-            the_breadcrumbs();
-        
+            cds_breadcrumb();
         ?>
- </div>
- </nav>
     </header>

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -99,6 +99,6 @@ declare(strict_types=1);
        
        
         <?php
-            cds_breadcrumb();
+            echo cds_breadcrumb();
         ?>
     </header>

--- a/wordpress/wp-content/themes/cds-default/header.php
+++ b/wordpress/wp-content/themes/cds-default/header.php
@@ -102,6 +102,18 @@ declare(strict_types=1);
                 <ol class="breadcrumb">
                     <li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>
                 </ol>
+
+                
             </div>
         </nav>
+        <nav id="wb-bc" property="breadcrumb">
+        <div class="container">
+        <h2><?php _e("You are here:"); ?></h2>
+        <?php
+        
+            the_breadcrumbs();
+        
+        ?>
+ </div>
+ </nav>
     </header>

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -131,42 +131,38 @@ function cds_the_posts_navigation($args = []): void
 
 /* https://wet-boew.github.io/GCWeb/sites/breadcrumbs/breadcrumbs-en.html */
 
-function cds_breadcrumb($sep = '')
+function cds_breadcrumb($sep = '') : string
 {
-    if (!function_exists('yoast_breadcrumb')) {
-        return null;
+    if (! function_exists('yoast_breadcrumb')) {
+        return "";
     }
-    
-    $crumbs = yoast_breadcrumb( '<div class="breadcrumbs">','</div>', false);
 
-    //
     try {
+        $crumbs = yoast_breadcrumb('<div class="breadcrumbs">', '</div>', false);
         $dom = new Dom();
         $dom->loadStr($crumbs);
         $node = $dom->find('.breadcrumbs');
         $child = $node->firstChild();
         $html = $child->firstChild()->innerHtml;
-        $parts = explode("|", $html);
+        $parts = explode('|', $html);
 
         $output = '<nav id="wb-bc" property="breadcrumb">';
-        $output.= '<div class="container">';
-        $output.= '<h2><?php _e("You are here:"); ?></h2>';
-        $output.= '<ol class="breadcrumb">';
+        $output .= '<div class="container">';
+        $output .= '<h2><?php _e("You are here:"); ?></h2>';
+        $output .= '<ol class="breadcrumb">';
         // note this will need to point to the correct language
-        $output.= '<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>';
-        foreach($parts as $part){
-        $output.= '<li>';
-           $output.=$part; 
-           $output.= '</li>';
+        $output .= '<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>';
+        foreach ($parts as $part) {
+            $output .= '<li>';
+            $output .= $part;
+            $output .= '</li>';
         }
-        
-        $output.= '</ol>';
-        $output.= '</div>';
-        $output.= '</nav>';
 
-        echo $output;
-
+        $output .= '</ol>';
+        $output .= '</div>';
+        $output .= '</nav>';
+        return $output;
     } catch (Exception $e) {
-        return "error";
+        return yoast_breadcrumb('<div class="breadcrumbs">', '</div>', false);
     }
 }

--- a/wordpress/wp-content/themes/cds-default/inc/template-functions.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-functions.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PHPHtmlParser\Dom;
+
 /**
  * Functions which enhance the theme by hooking into WordPress
  *
@@ -125,4 +127,46 @@ function cds_the_posts_navigation($args = []): void
     }
 
     echo $navigation;
+}
+
+/* https://wet-boew.github.io/GCWeb/sites/breadcrumbs/breadcrumbs-en.html */
+
+function cds_breadcrumb($sep = '')
+{
+    if (!function_exists('yoast_breadcrumb')) {
+        return null;
+    }
+    
+    $crumbs = yoast_breadcrumb( '<div class="breadcrumbs">','</div>', false);
+
+    //
+    try {
+        $dom = new Dom();
+        $dom->loadStr($crumbs);
+        $node = $dom->find('.breadcrumbs');
+        $child = $node->firstChild();
+        $html = $child->firstChild()->innerHtml;
+        $parts = explode("|", $html);
+
+        $output = '<nav id="wb-bc" property="breadcrumb">';
+        $output.= '<div class="container">';
+        $output.= '<h2><?php _e("You are here:"); ?></h2>';
+        $output.= '<ol class="breadcrumb">';
+        // note this will need to point to the correct language
+        $output.= '<li><a href="https://www.canada.ca/en.html">Canada.ca</a></li>';
+        foreach($parts as $part){
+        $output.= '<li>';
+           $output.=$part; 
+           $output.= '</li>';
+        }
+        
+        $output.= '</ol>';
+        $output.= '</div>';
+        $output.= '</nav>';
+
+        echo $output;
+
+    } catch (Exception $e) {
+        return "error";
+    }
 }

--- a/wordpress/wp-content/themes/cds-default/template-parts/content.php
+++ b/wordpress/wp-content/themes/cds-default/template-parts/content.php
@@ -34,10 +34,10 @@ declare(strict_types=1);
                     /* translators: %s: Name of current post. Only visible to screen readers */
                     __('Continue reading<span class="screen-reader-text"> "%s"</span>', 'cds'),
                          [
-                            'span' => [
-                                'class' => [],
-                            ],
-                        ]
+                             'span' => [
+                                 'class' => [],
+                             ],
+                         ]
                      ),
                      wp_kses_post(get_the_title())
                  )
@@ -53,16 +53,6 @@ declare(strict_types=1);
             </div><!-- .entry-meta -->
         <?php
         }
-        ?>
-      <?php
-        /*
-        wp_link_pages(
-            [
-                'before' => '<div class="page-links">' . esc_html__('Pages:', 'cds'),
-                'after' => '</div>',
-            ]
-        );
-        */
         ?>
     </div><!-- .entry-content -->
 


### PR DESCRIPTION
## Issue
Given a page such as 
https://platform.digital.canada.ca/blog-demo/2018/11/03/block-cover/

There's not an easy way to navigate back to the "site" homepage

Adds breadcrumb nav using "styled" Wordpress SEO (Yoast) breadcrumb output

ref: https://github.com/cds-snc/platform-mvp/pull/85

<img width="489" alt="Screen Shot 2021-08-20 at 9 27 16 AM" src="https://user-images.githubusercontent.com/62242/130240501-567ecddb-2b04-40b2-b148-23b15f2f6046.png">

## Setup  / Testing
- Locally visit the breadcrumbs settings page
http://localhost/wp-admin/admin.php?page=wpseo_titles#top#breadcrumbs

- Set the  "Separator between breadcrumbs" to "|" 
<img width="698" alt="Screen Shot 2021-08-20 at 9 29 56 AM" src="https://user-images.githubusercontent.com/62242/130240773-a4bc0bec-0b8c-4c9e-afff-93cbe4a0a2b9.png">

- View the local site 

<hr>

Notes: I tried doing the dom parsing / splitting based on the default Yoast separator but it wasn't detecting va the "|" ... I'll revisit that after we get some PHP unit tests setup. 



