### PR TITLE
Prettier php config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "phpVersion": "8.0",
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,158 @@
     "packages": {
         "": {
             "name": "platform-mvp",
-            "hasInstallScript": true
+            "hasInstallScript": true,
+            "devDependencies": {
+                "@prettier/plugin-php": "^0.17.3",
+                "prettier": "^2.3.2"
+            }
+        },
+        "node_modules/@prettier/plugin-php": {
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.17.3.tgz",
+            "integrity": "sha512-kD5IrGyKWF/p3XActVZ+GfbMl9knoK3XKBTG2bytpOtCO0+Q8eozimSgk/493rgFkXL3W2Ap/4GKgZf7u64+ow==",
+            "dev": true,
+            "dependencies": {
+                "linguist-languages": "^7.5.1",
+                "mem": "^8.0.0",
+                "php-parser": "git+https://github.com/glayzzle/php-parser.git#e61e26102144f267ecf5e09020865a9baa6ca2f1"
+            },
+            "peerDependencies": {
+                "prettier": "^1.15.0 || ^2.0.0"
+            }
+        },
+        "node_modules/linguist-languages": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.15.0.tgz",
+            "integrity": "sha512-qkSSNDjDDycZ2Wcw+GziNBB3nNo3ddYUInM/PL8Amgwbd9RQ/BKGj2/1d6mdxKgBFnUqZuaDbkIwkE4KUwwmtQ==",
+            "dev": true
+        },
+        "node_modules/map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "dependencies": {
+                "p-defer": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "dependencies": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/mem?sponsor=1"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/php-parser": {
+            "version": "3.0.2",
+            "resolved": "git+ssh://git@github.com/glayzzle/php-parser.git#e61e26102144f267ecf5e09020865a9baa6ca2f1",
+            "integrity": "sha512-UAqZS0uEpa6wzDLGw7kfHiJhlMP/dX0HfSqSdqlTcNeuTl9s1VuVuwm/R375XfRm3gYkwfDkfZBJSWSq2EFG/Q==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/prettier": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@prettier/plugin-php": {
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.17.3.tgz",
+            "integrity": "sha512-kD5IrGyKWF/p3XActVZ+GfbMl9knoK3XKBTG2bytpOtCO0+Q8eozimSgk/493rgFkXL3W2Ap/4GKgZf7u64+ow==",
+            "dev": true,
+            "requires": {
+                "linguist-languages": "^7.5.1",
+                "mem": "^8.0.0",
+                "php-parser": "git+https://github.com/glayzzle/php-parser.git#e61e26102144f267ecf5e09020865a9baa6ca2f1"
+            }
+        },
+        "linguist-languages": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.15.0.tgz",
+            "integrity": "sha512-qkSSNDjDDycZ2Wcw+GziNBB3nNo3ddYUInM/PL8Amgwbd9RQ/BKGj2/1d6mdxKgBFnUqZuaDbkIwkE4KUwwmtQ==",
+            "dev": true
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "dev": true
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "php-parser": {
+            "version": "git+ssh://git@github.com/glayzzle/php-parser.git#e61e26102144f267ecf5e09020865a9baa6ca2f1",
+            "integrity": "sha512-UAqZS0uEpa6wzDLGw7kfHiJhlMP/dX0HfSqSdqlTcNeuTl9s1VuVuwm/R375XfRm3gYkwfDkfZBJSWSq2EFG/Q==",
+            "dev": true,
+            "from": "php-parser@git+https://github.com/glayzzle/php-parser.git#e61e26102144f267ecf5e09020865a9baa6ca2f1"
+        },
+        "prettier": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-    "name": "platform-mvp",
-    "scripts": {
-      "deploy-plugin": "./deploy/plugin",
-      "deploy-theme": "./deploy/theme",
-      "cli": "docker exec -it cli /bin/zsh",
-      "postinstall": "cd wordpress/wp-content/plugins/cds-base && npm install && npm run build"
-    }
+  "name": "platform-mvp",
+  "scripts": {
+    "deploy-plugin": "./deploy/plugin",
+    "deploy-theme": "./deploy/theme",
+    "cli": "docker exec -it cli /bin/zsh",
+    "postinstall": "cd wordpress/wp-content/plugins/cds-base && npm install && npm run build"
+  },
+  "devDependencies": {
+    "@prettier/plugin-php": "^0.17.3",
+    "prettier": "^2.3.2"
   }
-  
+}

--- a/wordpress/phpinsights.php
+++ b/wordpress/phpinsights.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-return [
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff;
 
+return [
     /*
     |--------------------------------------------------------------------------
     | Default Preset
@@ -50,9 +51,7 @@ return [
     |
     */
 
-    'exclude' => [
-
-    ],
+    'exclude' => [],
 
     'add' => [
         //  ExampleMetric::class => [
@@ -60,9 +59,7 @@ return [
         //  ]
     ],
 
-    'remove' => [
-        //  ExampleInsight::class,
-    ],
+    'remove' => [SpaceAfterNotSniff::class],
 
     'config' => [
         //  ExampleInsight::class => [
@@ -101,5 +98,4 @@ return [
     */
 
     'threads' => null,
-
 ];


### PR DESCRIPTION
# Summary | Résumé

Adds [prettier-php](https://github.com/prettier/plugin-php) code formatting support.

After pulling down this change, be sure to `npm install` at the root of the project to pull in the dependencies. Then follow the [instructions here to configure PHPStorm](https://github.com/prettier/plugin-php#phpstorm--intellij--jetbrains-ide). There are instructions at that link for VS Code as well.

## Why prettier?
In investigating a bunch of different methods/tools for PHP code formatting, this was the easiest to setup, has the most crossover with PHP Insights rules, and should be easy to setup for any IDE.

## Compatibility with PHP Insights
Prettier-php has quite a bit of overlap with PHP Insights, but they're not a 1:1 match. So we may find we need to tweak rules in one or the other, according to our own preference. (See the "Remove" section of phpinsights.php for an example of a rule that had to be disabled for compatibility reasons)
