### PR TITLE
Increase php upload_max_filesize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - ./wordpress/.htaccess-multisite:/var/www/html/.htaccess
       - ./wordpress/docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - ./wordpress/docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
+      - ./wordpress/docker/php/conf.d/upload_max_filesize.ini:/usr/local/etc/php/conf.d/uplaod_max_filesize.ini
     networks:
       - app-network
 

--- a/wordpress/docker/php/conf.d/upload_max_filesize.ini
+++ b/wordpress/docker/php/conf.d/upload_max_filesize.ini
@@ -1,0 +1,1 @@
+upload_max_filesize = 50M


### PR DESCRIPTION
# Summary | Résumé

If you tried to install the WPML plugin using the WordPress UI on you local environment, you probably ran into an upload filesize limit, the default is 2M and the plugin is closer to 6M.

This adds a PHP config file to increase the filesize limit on uploads.