### PR TITLE
Add and enable two-factor plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       wp plugin activate wp-mail-smtp --network;
       wp plugin activate wordpress-importer --network;
       wp plugin activate wordpress-seo --network;
+      wp plugin activate two-factor --network;
       '
     volumes:
       - wordpress:/var/www/html

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -10,7 +10,8 @@
         "wpackagist-plugin/oasis-workflow": "^5.7",
         "wpackagist-plugin/wp-mail-smtp": "^3.0",
         "wpackagist-plugin/wordpress-importer": "^0.7.0",
-        "wpackagist-plugin/wordpress-seo": "^16.9"
+        "wpackagist-plugin/wordpress-seo": "^16.9",
+        "wpackagist-plugin/two-factor": "^0.7.0"
     },
     "require-dev": {
         "nunomaduro/phpinsights": "^2.0",

--- a/wordpress/composer.lock
+++ b/wordpress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a6c7c8b05898eef901be14d6e55d05e",
+    "content-hash": "3ac1c895b9609016b94e110262904df4",
     "packages": [
         {
             "name": "composer/installers",
@@ -173,6 +173,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/oasis-workflow/"
+        },
+        {
+            "name": "wpackagist-plugin/two-factor",
+            "version": "0.7.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/two-factor/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/two-factor.zip?timestamp=1620374007"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/two-factor/"
         },
         {
             "name": "wpackagist-plugin/wordpress-importer",
@@ -6440,5 +6458,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
# Summary | Résumé

Adds/enables the two-factor plugin for testing/evaluation.

Looks good so far - supports TOTP (time-based) and U2F security keys.

The experience of setting it up leaves a bit to be desired- the 2fa settings just get added to the already very crowded WordPress user profile edit screen. They kinda get lost.

Also, can't see an option to make 2fa mandatory for user account.

