### PR TITLE
Fix mailhog config for local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 ## Local dev
 
 Docker-compose and VS Code Remote Container environment featuring:
-  - mysql8
-  - wordpress (wordpress/apache)
-  - wp-cli & composer (devcontainer)
-  - mailhog (fake mail)
-  - phpmyadmin (db admin)
+
+- mysql8
+- wordpress (wordpress/apache)
+- wp-cli & composer (devcontainer)
+- mailhog (fake mail)
+- phpmyadmin (db admin)
 
 ## Requirements
+
 - NPM
 - Docker
 - Docker-compose
@@ -66,12 +68,14 @@ password: secret
 ## Useful services
 
 ### Mailhog
+
 Local mailcatcher for fake email sending. To use it, configure your WordPress install to use the SMTP interface.
 
 Web interface: `localhost:8025`
-SMTP interface: `localhost:1025`
+SMTP interface: `mailhog:1025`
 
 ### PHPMyAdmin
+
 Web admin for MySQL database.
 
 Web interface: `localhost:8080`
@@ -79,13 +83,15 @@ Web interface: `localhost:8080`
 ## Plugins and Themes
 
 Pre-installed plugins:
+
 - [oasis-workflow](https://www.oasisworkflow.com/)
 - [wordpress-importer](https://wordpress.org/plugins/wordpress-importer/)
 - [wp-mail-smtp](https://wordpress.org/plugins/wp-mail-smtp/)
 - [wp-rest-api-v2-menus](https://wordpress.org/plugins/wp-rest-api-v2-menus/)
 
 ### Installing
-This project is configured to use [Composer](https://getcomposer.org/) to manage [WordPress Themes and Plugins](https://www.smashingmagazine.com/2019/03/composer-wordpress/). 
+
+This project is configured to use [Composer](https://getcomposer.org/) to manage [WordPress Themes and Plugins](https://www.smashingmagazine.com/2019/03/composer-wordpress/).
 
 To install a plugin or theme, find it on [WPackagist](https://wpackagist.org/), add it to composer.json, and run `composer install` or use `composer require wpackagist-[plugin|theme]/[package-name]`. These commands should be run from within the `wordpress` folder.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     ports: 
       - 1025:1025 # smtp server
       - 8025:8025 # web ui
+    networks:
+      - app-network
 
   phpmyadmin:
     depends_on:


### PR DESCRIPTION
# Summary | Résumé

Put Mailhog on the same app-network as everything else, so that WP can see it when sending email. Note that in the docker-compose environment, the service is exposed on the hostname `mailhog`

So when working locally, you can configure the SMTP mailer as:

![image](https://user-images.githubusercontent.com/1187115/130504914-fed8d6a2-1200-4253-95c4-9be25e1bb2d3.png)

...and Mailhog will capture all outgoing mail from the wordpress service.