### PR TITLE
Fix invalid type for `on`  error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
-on:
-  - [push, pull_request]
+on: [push, pull_request]
 
 jobs:
   phpinsights:


### PR DESCRIPTION
# Summary | Résumé

Our CI checks have been failing due to invalid syntax