### PR TITLE
Notify template sender settings

### DIFF
--- a/wordpress/wp-content/plugins/cds-base/email/NotifySettings.php
+++ b/wordpress/wp-content/plugins/cds-base/email/NotifySettings.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+
+class NotifySettings extends NotifyTemplateSender
+{
+    public static string $admin_page = 'cds_notify_send';
+
+    public function __construct()
+    {
+        global $status, $page;
+    }
+
+    public static function add_menu(): void
+    {
+        add_submenu_page(parent::$admin_page, __('Settings'), __('Settings'), 'activate_plugins',
+            self::$admin_page . "_settings", ['NotifySettings', 'render_settings']);
+
+        add_action('admin_init', ['NotifySettings', 'register_settings']);
+    }
+
+    public static function register_settings(): void
+    {
+        register_setting('cds-settings-group', 'sender_type');
+        register_setting('cds-settings-group', 'list_values');
+    }
+
+    public static function render_select_option($data, $current_val): string
+    {
+        $str = '<option ';
+        $str .= 'value="' . $data['value'] . '"';
+
+        if ($data['value'] == $current_val) {
+            $str .= 'selected="selected"';
+        }
+        $str .= ">";
+        $str .= $data['label'];
+        $str .= "</option>";
+
+        return $str;
+    }
+
+    public static function render_settings(): void
+    {
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+            <form action='options.php' method='post'>
+                <?php settings_fields('cds-settings-group'); ?>
+                <?php do_settings_sections('cds-settings-group'); ?>
+                <table class="form-table">
+                    <!-- Sender Type -->
+                    <tr valign="top">
+                        <th scope="row"><?php _e("Sender Type", "cds-snc") ?></th>
+                        <td>
+                            <?php $current_val = esc_attr(get_option('sender_type')); ?>
+                            <select name="sender_type">
+                                <?php
+                                $label = __("List Manager", "cds-snc");
+                                $data = ["value" => "list_manager", 'label' => $label];
+                                echo self::render_select_option($data, $current_val);
+
+                                $label = __("WPForms", "cds-snc");
+                                $data = ["value" => "wp_forms", 'label' => $label];
+                                echo self::render_select_option($data, $current_val);
+                                ?>
+                            </select>
+                        </td>
+                    </tr>
+
+                    <!-- Sender Type -->
+                    <tr valign="top">
+                        <th scope="row"><?php _e("List Values JSON", "cds-snc") ?></th>
+                        <td>
+                            <?php $val = esc_attr(get_option('list_values')); ?>
+                            <textarea name="list_values" rows="4" cols="50"><?php echo $val; ?></textarea>
+
+                            <p class="description" id="new-admin-email-description"><?php _e("Format", "cds-snc") ?>:
+                            <pre>[{"id":"123", "type":"email", "label":"my-list"}]</pre>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                <?php
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/wordpress/wp-content/plugins/cds-base/email/NotifyTemplateSender.php
+++ b/wordpress/wp-content/plugins/cds-base/email/NotifyTemplateSender.php
@@ -107,7 +107,7 @@ class NotifyTemplateSender
                                         throw new ErrorException("unable to parse data");
                                     }
 
-                                    echo '<option value="">' . __("Select a list"). '</option>';
+                                    echo '<option value="">' . __("Select a list") . '</option>';
 
                                     foreach ($data as &$value) {
                                         echo '<option value="' . $value['id'] . '-' . $value['type'] . '">' . $value['label'] . '</option>';
@@ -151,7 +151,14 @@ class NotifyTemplateSender
             $list_id = $parts[0];
             $list_type = $parts[1];
 
-            $result = self::send($template_id, $list_id, $list_type, "WP Bulk send");
+            $sender_type = get_option('sender_type');
+
+            $result = match ($sender_type) {
+                "list_manager" => self::send($template_id, $list_id, $list_type, "WP Bulk send"),
+                "wp_forms" => self::send_internal($template_id, $list_id, $list_type, "WP Bulk send"),
+            };
+
+            // @todo ensure the status we're retuning is correct
             wp_redirect($base_redirect . "&status=200");
             exit();
         } catch (Exception $e) {
@@ -160,7 +167,7 @@ class NotifyTemplateSender
         }
     }
 
-    public function send_internal($templateId, $formId, $type): void
+    public static function send_internal($templateId, $formId, $type): void
     {
 
         // php loop send


### PR DESCRIPTION
Adds the ability to select a sender type and populate the list ID dropdown from the settings page

<img width="500" alt="Screen Shot 2021-09-01 at 9 48 23 AM" src="https://user-images.githubusercontent.com/62242/131684231-b75566ba-3793-4162-a041-5b71bab176ff.png">


<img width="718" alt="Screen Shot 2021-09-01 at 9 48 00 AM" src="https://user-images.githubusercontent.com/62242/131684258-1d72042d-b66a-480e-9a25-ccde82885cd6.png">

