### PR TITLE
Fix post date output

### DIFF
--- a/wordpress/wp-content/themes/cds-default/inc/template-tags.php
+++ b/wordpress/wp-content/themes/cds-default/inc/template-tags.php
@@ -18,15 +18,13 @@ if (! function_exists('cds_posted_on')) {
     {
         $time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
         if (get_the_time('U') !== get_the_modified_time('U')) {
-            $time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+            $time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>';
         }
 
         $time_string = sprintf(
             $time_string,
             esc_attr(get_the_date(DATE_W3C)),
-            esc_html(get_the_date()),
-            esc_attr(get_the_modified_date(DATE_W3C)),
-            esc_html(get_the_modified_date())
+            esc_html(get_the_date())
         );
 
         $posted_on = $time_string;


### PR DESCRIPTION
Fixes issue where dates were being rendered twice
i.e.

<img width="477" alt="Screen Shot 2021-09-14 at 2 37 15 PM" src="https://user-images.githubusercontent.com/62242/133316643-78b3a543-5098-4d73-898c-25b5f6ac839f.png">


Turns out it was rendering two different dates (published date and updated date)

<img width="731" alt="133314589-41da8871-a00f-48ff-a505-329c6aab11ad" src="https://user-images.githubusercontent.com/62242/133316765-483ccdd0-6061-4042-8b6e-626a4a820cd1.png">



This PR removes the updated date.

Note: Also fixed some undefined variables